### PR TITLE
Fixed width and height issues with component

### DIFF
--- a/components/sideButton.vue
+++ b/components/sideButton.vue
@@ -50,10 +50,9 @@ export default {
     .arrowNav {
         position: relative;
         font-size: 100px;
-        height: 100vh;
+        height: 100%;
         display: flex;
         flex-grow: 1;
-        width: 7vw;
         align-items: center;
         justify-content: center;
         color: white;


### PR DESCRIPTION
* default height is now 100% of height of component
* icon width was forcing component to be wider than the perceived component, forcing it to expand the width of the the viewport
